### PR TITLE
Replace Ant Design with MUIX

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,22 @@
+{
+    "cSpell.words": [
+        "Agentic",
+        "Behrus",
+        "bibtex",
+        "Colab",
+        "CUDA",
+        "DBIS",
+        "FAISS",
+        "Hanbin",
+        "javascripts",
+        "llms",
+        "Meret",
+        "Nasir",
+        "Önelmis",
+        "Puladi",
+        "Saif",
+        "Unbehaun",
+        "Weibo",
+        "Yongli"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -73,6 +73,17 @@ Role-based Interactions: The system is designed to serve two primary user roles:
 
 ## Usage
 
+## Getting Started
+
+First, run the development server:
+
+```bash
+npm install
+npm run dev
+```
+
+Open [http://localhost:3000](http://localhost:3000) with your browser to see the result.
+
 Here's an example of how to use the model:
 
 ```python
@@ -102,9 +113,9 @@ More detailed tutorials can be found in our [documentation](https://your-project
 
 ## Benchmark Results
 
-| Model        | MedQA | OMSRec |
-|--------------|-------:|---------:|
-| TransE | xx     | xx       |  xx.x%|  xx.x%  | xx.x%|
+| Model  | MedQA | OMSRec |
+| ------ | ----: | -----: |
+| TransE |    xx |     xx | xx.x% | xx.x% | xx.x% |
 
 More benchmarks are available in the [research paper](https://your-project-website.com/paper).
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,14 +9,16 @@
     "lint": "next lint"
   },
   "dependencies": {
-    "@ant-design/nextjs-registry": "^1.0.2",
-    "antd": "^5.24.1",
     "i18next": "^24.2.2",
     "next": "15.1.7",
     "next-i18next": "^15.4.2",
     "react": "~18.2.0",
     "react-dom": "~18.2.0",
-    "react-i18next": "^15.4.1"
+    "react-i18next": "^15.4.1",
+    "@mui/material": "^5.10.0",
+    "@emotion/react": "^11.7.1",
+    "@emotion/styled": "^11.x",
+    "@mui/icons-material": "^5.x"
   },
   "devDependencies": {
     "@eslint/eslintrc": "^3",

--- a/frontend/src/app/(auth)/sign-in/page.tsx
+++ b/frontend/src/app/(auth)/sign-in/page.tsx
@@ -1,8 +1,7 @@
-// app/(auth)/sign-in/page.tsx
 'use client';
 
 import React from 'react';
-import { Form, Input, Button } from 'antd';
+import { TextField, Button, Box } from '@mui/material';
 
 const SignInPage: React.FC = () => {
   const onFinish = (values: any) => {
@@ -11,30 +10,31 @@ const SignInPage: React.FC = () => {
   };
 
   return (
-    <div style={{ maxWidth: 300, margin: '50px auto', padding: '20px', boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}>
+    <Box sx={{ maxWidth: 300, margin: '50px auto', padding: '20px', boxShadow: '0 0 10px rgba(0,0,0,0.1)' }}>
       <h2 style={{ textAlign: 'center' }}>Sign In</h2>
-      <Form name="sign_in" onFinish={onFinish} layout="vertical">
-        <Form.Item 
-          label="Username" 
-          name="username" 
-          rules={[{ required: true, message: 'Please enter the username!' }]}
-        >
-          <Input placeholder="Please enter the username" />
-        </Form.Item>
-        <Form.Item 
-          label="password" 
-          name="password" 
-          rules={[{ required: true, message: 'Please enter the password!' }]}
-        >
-          <Input.Password placeholder="Please enter the password" />
-        </Form.Item>
-        <Form.Item>
-          <Button type="primary" htmlType="submit" style={{ width: '100%' }}>
-            Sign In
-          </Button>
-        </Form.Item>
-      </Form>
-    </div>
+      <form onSubmit={onFinish}>
+        <TextField
+          label="Username"
+          name="username"
+          required
+          fullWidth
+          margin="normal"
+          placeholder="Please enter the username"
+        />
+        <TextField
+          label="Password"
+          name="password"
+          type="password"
+          required
+          fullWidth
+          margin="normal"
+          placeholder="Please enter the password"
+        />
+        <Button type="submit" variant="contained" color="primary" fullWidth>
+          Sign In
+        </Button>
+      </form>
+    </Box>
   );
 };
 

--- a/frontend/src/app/(protected)/chat/layout.tsx
+++ b/frontend/src/app/(protected)/chat/layout.tsx
@@ -1,10 +1,7 @@
-// src/app/(protected)/chat/layout.tsx
 'use client';
 import React from 'react';
-import { Layout } from 'antd';
+import { Box, Grid } from '@mui/material';
 import ChatSidebar from '@/components/common/Sidebar/ChatSidebar';
-
-const { Sider, Content } = Layout;
 
 interface ChatLayoutProps {
   children: React.ReactNode;
@@ -12,16 +9,16 @@ interface ChatLayoutProps {
 
 const ChatLayout: React.FC<ChatLayoutProps> = ({ children }) => {
   return (
-    <Layout style={{ minHeight: '100vh' }}>
+    <Box sx={{ minHeight: '100vh', display: 'flex' }}>
       {/* 左侧 Sider */}
-      <Sider width={200} style={{ background: '#fff' }}>
+      <Box sx={{ width: 200, background: '#fff' }}>
         <ChatSidebar />
-      </Sider>
+      </Box>
 
       {/* 右侧内容区域 */}
-      <Layout style={{ padding: '24px' }}>
-        <Content
-          style={{
+      <Box sx={{ flex: 1, padding: '24px' }}>
+        <Box
+          sx={{
             background: '#fff',
             padding: '24px',
             margin: 0,
@@ -29,11 +26,10 @@ const ChatLayout: React.FC<ChatLayoutProps> = ({ children }) => {
           }}
         >
           {children}
-        </Content>
-      </Layout>
-    </Layout>
+        </Box>
+      </Box>
+    </Box>
   );
 };
 
 export default ChatLayout;
-

--- a/frontend/src/app/(protected)/chat/page.tsx
+++ b/frontend/src/app/(protected)/chat/page.tsx
@@ -1,8 +1,8 @@
 'use client';
 
 import React, { useState } from 'react';
-import { List, Input, Button, Typography, Divider } from 'antd';
-import { SendOutlined } from '@ant-design/icons';
+import { List, TextField, Button, Typography, Divider } from '@mui/material';
+import SendIcon from '@mui/icons-material/Send';
 
 const { Text } = Typography;
 
@@ -69,16 +69,21 @@ const ChatPage: React.FC = () => {
 
       {/* 输入框和发送按钮 */}
       <div style={styles.inputArea}>
-        <Input
+        <TextField
           value={inputValue}
           onChange={(e) => setInputValue(e.target.value)}
-          onPressEnter={handleSend}
+          onKeyPress={(e) => {
+            if (e.key === 'Enter') {
+              handleSend();
+            }
+          }}
           placeholder="Enter the message..."
           style={{ marginRight: 8 }}
         />
         <Button
-          type="primary"
-          icon={<SendOutlined />}
+          variant="contained"
+          color="primary"
+          endIcon={<SendIcon />}
           onClick={handleSend}
         >
           Send
@@ -102,7 +107,7 @@ const styles: { [key: string]: React.CSSProperties } = {
     wordWrap: 'break-word',
   },
   bubbleMine: {
-    backgroundColor: '#1890ff',
+    backgroundColor: '#1976d2',
     color: '#fff',
   },
   bubbleOther: {

--- a/frontend/src/app/(protected)/dashboard/layout.tsx
+++ b/frontend/src/app/(protected)/dashboard/layout.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import React from 'react';
-import { Layout } from 'antd';
+import { Box, Grid } from '@mui/material';
 import DashboardSidebar from '@/components/common/Sidebar/DashboardSidebar';
 import withRole from '@/auth/withRole';
-
-const { Sider, Content } = Layout;
 
 interface DashboardLayoutProps {
   children: React.ReactNode;
@@ -13,13 +11,16 @@ interface DashboardLayoutProps {
 
 const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Sider width={200} style={{ background: '#fff' }}>
+    <Box sx={{ minHeight: '100vh', display: 'flex' }}>
+      {/* 左侧 Sider */}
+      <Box sx={{ width: 200, background: '#fff' }}>
         <DashboardSidebar />
-      </Sider>
-      <Layout style={{ padding: '24px' }}>
-        <Content
-          style={{
+      </Box>
+
+      {/* 右侧内容区域 */}
+      <Box sx={{ flex: 1, padding: '24px' }}>
+        <Box
+          sx={{
             background: '#fff',
             padding: '24px',
             margin: 0,
@@ -27,12 +28,10 @@ const DashboardLayout: React.FC<DashboardLayoutProps> = ({ children }) => {
           }}
         >
           {children}
-        </Content>
-      </Layout>
-    </Layout>
+        </Box>
+      </Box>
+    </Box>
   );
 };
-
-// export default DashboardLayout;
 
 export default withRole(DashboardLayout, ['admin']);

--- a/frontend/src/app/(protected)/dashboard/page.tsx
+++ b/frontend/src/app/(protected)/dashboard/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Typography, Row, Col, Card } from 'antd';
+import { Typography, Grid, Card } from '@mui/material';
 
 const { Title, Paragraph } = Typography;
 
@@ -17,16 +17,16 @@ const DashboardPage: React.FC = () => {
       <Title level={2}>Dashboard Overview</Title>
       <Paragraph>Here you can see a quick snapshot of system metrics.</Paragraph>
 
-      <Row gutter={16}>
+      <Grid container spacing={2}>
         {stats.map((item, index) => (
-          <Col key={index} xs={24} sm={12} md={8}>
+          <Grid item key={index} xs={12} sm={6} md={4}>
             <Card style={{ marginBottom: '16px' }}>
               <Title level={4}>{item.title}</Title>
               <Paragraph style={{ fontSize: '1.5rem', fontWeight: 'bold' }}>{item.value}</Paragraph>
             </Card>
-          </Col>
+          </Grid>
         ))}
-      </Row>
+      </Grid>
     </div>
   );
 };

--- a/frontend/src/app/(protected)/studio/layout.tsx
+++ b/frontend/src/app/(protected)/studio/layout.tsx
@@ -1,10 +1,8 @@
 'use client';
 
 import React from 'react';
-import { Layout } from 'antd';
+import { Box, Grid } from '@mui/material';
 import StudioSidebar from '@/components/common/Sidebar/StudioSidebar';
-
-const { Sider, Content } = Layout;
 
 interface StudioLayoutProps {
   children: React.ReactNode;
@@ -12,13 +10,16 @@ interface StudioLayoutProps {
 
 const StudioLayout: React.FC<StudioLayoutProps> = ({ children }) => {
   return (
-    <Layout style={{ minHeight: '100vh' }}>
-      <Sider width={200} style={{ background: '#fff' }}>
+    <Box sx={{ minHeight: '100vh', display: 'flex' }}>
+      {/* 左侧 Sider */}
+      <Box sx={{ width: 200, background: '#fff' }}>
         <StudioSidebar />
-      </Sider>
-      <Layout style={{ padding: '24px' }}>
-        <Content
-          style={{
+      </Box>
+
+      {/* 右侧内容区域 */}
+      <Box sx={{ flex: 1, padding: '24px' }}>
+        <Box
+          sx={{
             background: '#fff',
             padding: '24px',
             margin: 0,
@@ -26,9 +27,9 @@ const StudioLayout: React.FC<StudioLayoutProps> = ({ children }) => {
           }}
         >
           {children}
-        </Content>
-      </Layout>
-    </Layout>
+        </Box>
+      </Box>
+    </Box>
   );
 };
 

--- a/frontend/src/app/(protected)/studio/page.tsx
+++ b/frontend/src/app/(protected)/studio/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React from 'react';
-import { Typography, Divider } from 'antd';
+import { Typography, Divider } from '@mui/material';
 
 const { Title, Paragraph } = Typography;
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -1,4 +1,3 @@
-// app/layout.tsx
 'use client';
 
 import React, { useEffect, useState } from 'react';
@@ -8,6 +7,7 @@ import { initReactI18next } from 'react-i18next';
 import AppHeader from '@/components/common/Header';
 import AppFooter from '@/components/common/Footer';
 import { getOptions, languages } from '@/i18n/settings';
+import { Box, Grid } from '@mui/material';
 
 const i18n = i18next.createInstance();
 

--- a/frontend/src/app/page.tsx
+++ b/frontend/src/app/page.tsx
@@ -1,9 +1,8 @@
-// // app/page.tsx
 'use client';
 
 import React from 'react';
-import { Typography, Row, Col, Divider, Button } from 'antd';
-import { RocketOutlined, SearchOutlined, ExperimentOutlined } from '@ant-design/icons';
+import { Typography, Grid, Divider, Button } from '@mui/material';
+import { RocketLaunchOutlined, SearchOutlined, ScienceOutlined } from '@mui/icons-material';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
 import ExpandableCard from '@/components/common/ExpandableCard';
@@ -39,7 +38,7 @@ const HomePage: React.FC = () => {
         <Paragraph style={{ fontSize: '1.1rem' }}>
           {t('home.subtitle')}
         </Paragraph>
-        <Button type="primary" size="large">
+        <Button variant="contained" color="primary" size="large">
           <Link href="/chat">{t('home.try_now')}</Link>
         </Button>
       </div>
@@ -47,29 +46,29 @@ const HomePage: React.FC = () => {
       <Divider />
 
       {/* 系统介绍 - 三个卡片保持等高 */}
-      <Row gutter={[24, 24]} justify="center">
-        <Col xs={24} sm={12} md={8}>
+      <Grid container spacing={2} justifyContent="center">
+        <Grid item xs={12} sm={6} md={4}>
           <ExpandableCard
-            icon={<RocketOutlined style={{ fontSize: '2.5rem', color: '#1890ff' }} />}
+            icon={<RocketLaunchOutlined style={{ fontSize: '2.5rem', color: '#1890ff' }} />}
             title="高效检索"
             text={longText1}
           />
-        </Col>
-        <Col xs={24} sm={12} md={8}>
+        </Grid>
+        <Grid item xs={12} sm={6} md={4}>
           <ExpandableCard
             icon={<SearchOutlined style={{ fontSize: '2.5rem', color: '#52c41a' }} />}
             title="智能问答"
             text={longText2}
           />
-        </Col>
-        <Col xs={24} sm={12} md={8}>
+        </Grid>
+        <Grid item xs={12} sm={6} md={4}>
           <ExpandableCard
-            icon={<ExperimentOutlined style={{ fontSize: '2.5rem', color: '#faad14' }} />}
+            icon={<ScienceOutlined style={{ fontSize: '2.5rem', color: '#faad14' }} />}
             title="AI 工作流"
             text={longText3}
           />
-        </Col>
-      </Row>
+        </Grid>
+      </Grid>
 
       <Divider style={{ margin: '48px 0' }} />
 
@@ -86,7 +85,7 @@ const HomePage: React.FC = () => {
         <Paragraph style={{ fontSize: '1.1rem' }}>
           输入您的医疗问题，我们的系统将结合最新指南和文献，为您提供个性化的解答和推荐。
         </Paragraph>
-        <Button type="primary" size="large">
+        <Button variant="contained" color="primary" size="large">
           <Link href="/chat">开始问答</Link>
         </Button>
       </div>
@@ -95,4 +94,3 @@ const HomePage: React.FC = () => {
 };
 
 export default HomePage;
-

--- a/frontend/src/components/common/ExpandableCard.tsx
+++ b/frontend/src/components/common/ExpandableCard.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import React, { useState, useRef, useEffect } from 'react';
-import { Card, Button, Typography } from 'antd';
+import { Card, Button, Typography } from '@mui/material';
 
 const { Title, Paragraph } = Typography;
 
@@ -34,7 +34,7 @@ const ExpandableCard: React.FC<ExpandableCardProps> = ({ icon, title, text }) =>
 
   return (
     <Card
-      variant="borderless"
+      variant="outlined"
       style={{
         textAlign: 'center',
         display: 'flex',
@@ -57,7 +57,7 @@ const ExpandableCard: React.FC<ExpandableCardProps> = ({ icon, title, text }) =>
         <Paragraph>{text}</Paragraph>
       </div>
       {needsExpand && (
-        <Button type="link" onClick={toggleExpand}>
+        <Button variant="text" onClick={toggleExpand}>
           {expanded ? '收起' : '点击详情'}
         </Button>
       )}

--- a/frontend/src/components/common/Footer.tsx
+++ b/frontend/src/components/common/Footer.tsx
@@ -1,14 +1,13 @@
-// components/common/Footer.tsx
 import React from 'react';
-import { Layout } from 'antd';
-
-const { Footer } = Layout;
+import { Box, Typography } from '@mui/material';
 
 const AppFooter: React.FC = () => {
   return (
-    <Footer style={{ textAlign: 'center' }}>
-      MedAgent ©2025 Created by RWTH (DBIS)
-    </Footer>
+    <Box sx={{ textAlign: 'center', padding: '20px', backgroundColor: '#f0f0f0' }}>
+      <Typography variant="body2" color="textSecondary">
+        MedAgent ©2025 Created by RWTH (DBIS)
+      </Typography>
+    </Box>
   );
 };
 

--- a/frontend/src/components/common/Header.tsx
+++ b/frontend/src/components/common/Header.tsx
@@ -1,55 +1,35 @@
-// components/common/Header.tsx
 'use client';
 
 import React from 'react';
-import { Layout, Button, Space } from 'antd';
-import { UserOutlined } from '@ant-design/icons';
+import { AppBar, Toolbar, Button, IconButton, Box } from '@mui/material';
+import PersonOutlineOutlined from '@mui/icons-material/PersonOutlineOutlined';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
-import AppNav from '@/components/common/Nav';
+import AppNav from './Nav';
 import LanguageSwitcher from '@/components/common/LanguageSwitcher';
-
-const { Header } = Layout;
-
-const menuItems = [
-  { key: 'nav1', label: 'nav 1' },
-  { key: 'nav2', label: 'nav 2' },
-  { key: 'nav3', label: 'nav 3' },
-];
 
 const AppHeader: React.FC = () => {
   const { t } = useTranslation();
 
   return (
-    <Header
-      style={{
-        display: 'flex',
-        alignItems: 'center',
-        backgroundColor: '#001529', // 深色背景
-        justifyContent: 'space-between',
-        padding: '0 20px',
-      }}
-    >
-      {/* 左侧 Logo */}
-      <div style={{ flex: 'none', color: '#fff', fontSize: '1.2rem', fontWeight: 'bold' }}>
-        MedAgent
-      </div>
-
-      {/* 中间导航 */}  
-      <div style={{ flex: 1, overflow: 'hidden', display: 'flex', justifyContent: 'center' }}>
-        <AppNav />
-      </div>
-
-      {/* 右侧语言切换器和登录按钮 */}
-      <Space>
-        <LanguageSwitcher />
-        <Link href="/sign-in">
-          <Button type="primary" shape="round" icon={<UserOutlined />}>
-            {t('nav.sign_in')}
-          </Button>
-        </Link>
-      </Space>
-    </Header>
+    <AppBar position="static" style={{ backgroundColor: '#001529' }}>
+      <Toolbar style={{ display: 'flex', justifyContent: 'space-between' }}>
+        <Box style={{ flex: 'none', color: '#fff', fontSize: '1.2rem', fontWeight: 'bold' }}>
+          MedAgent
+        </Box>
+        <Box style={{ flex: 1, overflow: 'hidden', display: 'flex', justifyContent: 'center' }}>
+          <AppNav />
+        </Box>
+        <Box>
+          <LanguageSwitcher />
+          <Link href="/sign-in">
+            <Button variant="contained" color="primary" startIcon={<PersonOutlineOutlined />}>
+              {t('nav.sign_in')}
+            </Button>
+          </Link>
+        </Box>
+      </Toolbar>
+    </AppBar>
   );
 };
 

--- a/frontend/src/components/common/LanguageSwitcher.tsx
+++ b/frontend/src/components/common/LanguageSwitcher.tsx
@@ -1,11 +1,9 @@
 'use client';
 
 import React from 'react';
-import { Select } from 'antd';
+import { Select, MenuItem } from '@mui/material';
 import { useTranslation } from 'react-i18next';
 import { languages, languageLabels } from '@/i18n/settings';
-
-const { Option } = Select;
 
 const LanguageSwitcher: React.FC = () => {
     const { i18n } = useTranslation();
@@ -20,12 +18,12 @@ const LanguageSwitcher: React.FC = () => {
         <Select
             defaultValue={i18n.language || 'en'}
             style={{ width: 100 }}
-            onChange={handleChange}
+            onChange={(event) => handleChange(event.target.value)}
         >
             {languages.map((lang) => (
-                <Option key={lang} value={lang}>
+                <MenuItem key={lang} value={lang}>
                     {languageLabels[lang]}
-                </Option>
+                </MenuItem>
             ))}
         </Select>
     );

--- a/frontend/src/components/common/Nav.tsx
+++ b/frontend/src/components/common/Nav.tsx
@@ -1,13 +1,15 @@
-// components/common/Navigation.tsx
-
+'use client';
 import React from 'react';
-import { Menu } from 'antd';
+import { Menu, MenuItem } from '@mui/material';
 import Link from 'next/link';
 import { useTranslation } from 'react-i18next';
-import { HomeOutlined, MessageOutlined, EditOutlined, DashboardOutlined } from '@ant-design/icons';
+import HomeOutlined from '@mui/icons-material/HomeOutlined';
+import MessageOutlined from '@mui/icons-material/MessageOutlined';
+import EditOutlined from '@mui/icons-material/EditOutlined';
+import DashboardOutlined from '@mui/icons-material/DashboardOutlined';
 import { usePathname } from 'next/navigation';
 
-const AppNav: React.FC = () => {
+export default function AppNav() {
   const { t } = useTranslation();
 
   const pathname = usePathname();
@@ -34,9 +36,12 @@ const AppNav: React.FC = () => {
       selectedKeys={[selectedKey]}  // now controlled by the current route
       theme="dark"
       style={{ flex: 1, overflow: 'hidden', display: 'flex', justifyContent: 'center' }}
-      items={menuItems}
-    />
+    >
+      {menuItems.map((item) => (
+        <MenuItem key={item.key} icon={item.icon}>
+          {item.label}
+        </MenuItem>
+      ))}
+    </Menu>
   );
-};
-
-export default AppNav;
+}

--- a/frontend/src/components/common/Sidebar/ChatSidebar.tsx
+++ b/frontend/src/components/common/Sidebar/ChatSidebar.tsx
@@ -1,12 +1,9 @@
-// src/components/common/sidebar/ChatSidebar.tsx
 'use client';
 import React from 'react';
-import { Menu } from 'antd';
-import type { MenuProps } from 'antd';
-import { MessageOutlined, SearchOutlined, UserOutlined, NotificationOutlined } from '@ant-design/icons';
+import { Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import { MessageOutlined, SearchOutlined, UserOutlined, NotificationOutlined } from '@mui/icons-material';
 
-
-const items: MenuProps['items'] = [
+const items = [
   {
     key: 'chats',
     icon: <MessageOutlined />,
@@ -43,8 +40,23 @@ const ChatSidebar: React.FC = () => {
       defaultSelectedKeys={['current']}
       defaultOpenKeys={['sub1']}
       style={{ height: '100%', borderRight: 0 }}
-      items={items}
-    />
+    >
+      {items.map((item) => (
+        <MenuItem key={item.key}>
+          <ListItemIcon>{item.icon}</ListItemIcon>
+          <ListItemText primary={item.label} />
+          {item.children && (
+            <Menu>
+              {item.children.map((child) => (
+                <MenuItem key={child.key}>
+                  <ListItemText primary={child.label} />
+                </MenuItem>
+              ))}
+            </Menu>
+          )}
+        </MenuItem>
+      ))}
+    </Menu>
   );
 };
 

--- a/frontend/src/components/common/Sidebar/DashboardSidebar.tsx
+++ b/frontend/src/components/common/Sidebar/DashboardSidebar.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import React from 'react';
-import { Menu } from 'antd';
-import type { MenuProps } from 'antd';
-import { DashboardOutlined, BarChartOutlined, FileOutlined } from '@ant-design/icons';
+import { Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import { DashboardOutlined, BarChartOutlined, FileOutlined } from '@mui/icons-material';
 
-const items: MenuProps['items'] = [
+const items = [
   {
     key: 'overview',
     icon: <DashboardOutlined />,
@@ -29,8 +28,14 @@ const DashboardSidebar: React.FC = () => {
       mode="inline"
       defaultSelectedKeys={['overview']}
       style={{ height: '100%', borderRight: 0 }}
-      items={items}
-    />
+    >
+      {items.map((item) => (
+        <MenuItem key={item.key}>
+          <ListItemIcon>{item.icon}</ListItemIcon>
+          <ListItemText primary={item.label} />
+        </MenuItem>
+      ))}
+    </Menu>
   );
 };
 

--- a/frontend/src/components/common/Sidebar/StudioSidebar.tsx
+++ b/frontend/src/components/common/Sidebar/StudioSidebar.tsx
@@ -1,11 +1,10 @@
 'use client';
 
 import React from 'react';
-import { Menu } from 'antd';
-import type { MenuProps } from 'antd';
-import { EditOutlined, FolderOpenOutlined, SettingOutlined } from '@ant-design/icons';
+import { Menu, MenuItem, ListItemIcon, ListItemText } from '@mui/material';
+import { EditOutlined, FolderOpenOutlined, SettingsOutlined } from '@mui/icons-material';
 
-const items: MenuProps['items'] = [
+const items = [
   {
     key: 'projects',
     icon: <EditOutlined />,
@@ -18,7 +17,7 @@ const items: MenuProps['items'] = [
   },
   {
     key: 'settings',
-    icon: <SettingOutlined />,
+    icon: <SettingsOutlined />,
     label: 'Settings',
   },
 ];
@@ -29,8 +28,14 @@ const StudioSidebar: React.FC = () => {
       mode="inline"
       defaultSelectedKeys={['projects']}
       style={{ height: '100%', borderRight: 0 }}
-      items={items}
-    />
+    >
+      {items.map((item) => (
+        <MenuItem key={item.key}>
+          <ListItemIcon>{item.icon}</ListItemIcon>
+          <ListItemText primary={item.label} />
+        </MenuItem>
+      ))}
+    </Menu>
   );
 };
 


### PR DESCRIPTION
Replace Ant Design components with MUIX components across the project.

* **Dependencies**:
  - Remove `antd` and `@ant-design/nextjs-registry` from `frontend/package.json`.
  - Add `@mui/material`, `@emotion/react`, `@emotion/styled`, and `@mui/icons-material` to `frontend/package.json`.

* **Sign-In Page**:
  - Replace Ant Design `Form`, `Input`, and `Button` with MUIX `TextField`, `Button`, and `Box` in `frontend/src/app/(auth)/sign-in/page.tsx`.

* **Layouts**:
  - Replace Ant Design `Layout` with MUIX `Box` and `Grid` in `frontend/src/app/(protected)/chat/layout.tsx`, `frontend/src/app/(protected)/dashboard/layout.tsx`, and `frontend/src/app/(protected)/studio/layout.tsx`.

* **Chat Page**:
  - Replace Ant Design `List`, `Input`, `Button`, and `Typography` with MUIX equivalents in `frontend/src/app/(protected)/chat/page.tsx`.

* **Dashboard Page**:
  - Replace Ant Design `Typography`, `Row`, `Col`, and `Card` with MUIX equivalents in `frontend/src/app/(protected)/dashboard/page.tsx`.

* **Studio Page**:
  - Replace Ant Design `Typography` and `Divider` with MUIX equivalents in `frontend/src/app/(protected)/studio/page.tsx`.

* **Common Components**:
  - Replace Ant Design components with MUIX equivalents in `frontend/src/components/common/ExpandableCard.tsx`, `frontend/src/components/common/Footer.tsx`, `frontend/src/components/common/Header.tsx`, `frontend/src/components/common/LanguageSwitcher.tsx`, `frontend/src/components/common/Nav.tsx`, `frontend/src/components/common/Sidebar/ChatSidebar.tsx`, `frontend/src/components/common/Sidebar/DashboardSidebar.tsx`, and `frontend/src/components/common/Sidebar/StudioSidebar.tsx`.

* **Home Page**:
  - Replace Ant Design `Typography`, `Row`, `Col`, `Divider`, and `Button` with MUIX equivalents in `frontend/src/app/page.tsx`.

* **Layout**:
  - Replace Ant Design components with MUIX equivalents in `frontend/src/app/layout.tsx`.

* **README**:
  - Add a "Getting Started" section with instructions to run the development server.

